### PR TITLE
ignore-errors when vai is nil

### DIFF
--- a/quail-cin.el
+++ b/quail-cin.el
@@ -105,14 +105,14 @@ DEFAULT will be returned when some candidates are not in the ATTRS."
 
 (defun cin-safe-quote (val)
   "Return a quoted string built from VAL."
-  (replace-regexp-in-string
-   ";" (regexp-quote (regexp-quote "\\;"))
-   (replace-regexp-in-string
-    "\\\\" (regexp-quote (regexp-quote "\\\\"))
+  (ignore-errors
     (replace-regexp-in-string
-     "\"" "#-#\\\""
-      val t t)))
-  )
+     ";" (regexp-quote (regexp-quote "\\;"))
+     (replace-regexp-in-string
+      "\\\\" (regexp-quote (regexp-quote "\\\\"))
+      (replace-regexp-in-string
+       "\"" "#-#\\\""
+       val t t)))))
 
 (defun cin-filename-p (file-name &optional allow-dir)
   "Return t if the FILE-NAME is a valid cin file or a directory if ALLOW-DIR is t."


### PR DESCRIPTION
前情 https://github.com/letoh/quail-cin/issues/1

問題是 cin-safe-quote 發現傳入的 val 值為 nil 而發生錯誤，目前用 ignore-errors 忽略錯誤，或也可用。 `(if (string= val nil) (setq val ""))` 將 nil 還原成空字串處理。